### PR TITLE
fixing silk-flask setup path in wsgi

### DIFF
--- a/silk_config/wsgi.py
+++ b/silk_config/wsgi.py
@@ -1,5 +1,5 @@
 #place this file in www-root/
 
 import sys
-sys.path.insert(0,"/users/j/r/jrubin/www-root/<name_of_project>")
+sys.path.insert(0,"/users/j/r/jrubin8/www-root/auto-register")
 from app import app as application


### PR DESCRIPTION
I updated the path in wsgi.py from jrubin to jrubin8 because it was incorrect. Keep in mind, these files should be placed in the www-root/ directory.